### PR TITLE
refactor: add version and change names to endpoints

### DIFF
--- a/internal/handler/creditcard.go
+++ b/internal/handler/creditcard.go
@@ -28,23 +28,23 @@ func NewCreditCardHandler(svc service.CreditCardService) CreditCardHandler {
 }
 
 func (h *creditCardHandler) RegisterRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("POST /creditCard", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("POST /v1/creditCards", func(w http.ResponseWriter, r *http.Request) {
 		h.CreateCreditCard(w, r)
 	})
 
-	mux.HandleFunc("PUT /creditCard", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("PUT /v1/creditCards", func(w http.ResponseWriter, r *http.Request) {
 		h.UpdateCreditCard(w, r)
 	})
 
-	mux.HandleFunc("DELETE /creditCard/{id}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("DELETE /v1/creditCards/{id}", func(w http.ResponseWriter, r *http.Request) {
 		h.DeleteCreditCard(w, r)
 	})
 
-	mux.HandleFunc("GET /creditCard/{id}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /v1/creditCards/{id}", func(w http.ResponseWriter, r *http.Request) {
 		h.FindCreditCardByID(w, r)
 	})
 
-	mux.HandleFunc("GET /creditCards", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /v1/creditCards", func(w http.ResponseWriter, r *http.Request) {
 		h.FindAllCreditCards(w, r)
 	})
 }

--- a/internal/handler/installment.go
+++ b/internal/handler/installment.go
@@ -25,19 +25,19 @@ func NewInstallmentHandler(svc service.InstallmentService) InstallmentHandler {
 }
 
 func (h *installmentHandler) RegisterRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("PUT /installment/{id}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("PUT /v1/installments/{id}", func(w http.ResponseWriter, r *http.Request) {
 		h.UpdateInstallment(w, r)
 	})
 
-	mux.HandleFunc("GET /installment/{id}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /v1/installments/{id}", func(w http.ResponseWriter, r *http.Request) {
 		h.FindInstallmentByPurchaseID(w, r)
 	})
 
-	mux.HandleFunc("GET /installment/month/{date}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /v1/installments/month/{date}", func(w http.ResponseWriter, r *http.Request) {
 		h.FindInstallmentByMonth(w, r)
 	})
 
-	mux.HandleFunc("GET /installment/notPaid", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /v1/installments/notPaid", func(w http.ResponseWriter, r *http.Request) {
 		h.FindInstallmentByNotPaid(w, r)
 	})
 }

--- a/internal/handler/payment_type.go
+++ b/internal/handler/payment_type.go
@@ -28,23 +28,23 @@ func NewPaymentTypeHandler(svc service.PaymentTypeService) PaymentTypeHandler {
 }
 
 func (h *paymentTypeHandler) RegisterRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("POST /paymentType", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("POST /v1/paymentTypes", func(w http.ResponseWriter, r *http.Request) {
 		h.CreatePaymentType(w, r)
 	})
 	
-	mux.HandleFunc("PUT /paymentType", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("PUT /v1/paymentTypes", func(w http.ResponseWriter, r *http.Request) {
 		h.UpdatePaymentType(w, r)
 	})
 
-	mux.HandleFunc("DELETE /paymentType/{id}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("DELETE /v1/paymentTypes/{id}", func(w http.ResponseWriter, r *http.Request) {
 		h.DeletePaymentType(w, r)
 	})
 
-	mux.HandleFunc("GET /paymentType/{id}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /v1/paymentTypes/{id}", func(w http.ResponseWriter, r *http.Request) {
 		h.FindPaymentTypeByID(w, r)
 	})
 
-	mux.HandleFunc("GET /paymentTypes", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /v1/paymentTypes", func(w http.ResponseWriter, r *http.Request) {
 		h.FindAllPaymentTypes(w, r)
 	})
 }

--- a/internal/handler/person.go
+++ b/internal/handler/person.go
@@ -28,23 +28,23 @@ func NewPersonHandler(svc service.PersonService) PersonHandler {
 }
 
 func (h *personHandler) RegisterRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("POST /person", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("POST /v1/persons", func(w http.ResponseWriter, r *http.Request) {
 		h.CreatePerson(w, r)
 	})
 
-	mux.HandleFunc("PUT /person", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("PUT /v1/persons", func(w http.ResponseWriter, r *http.Request) {
 		h.UpdatePerson(w, r)
 	})
 
-	mux.HandleFunc("DELETE /person/{id}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("DELETE /v1/persons/{id}", func(w http.ResponseWriter, r *http.Request) {
 		h.DeletePerson(w, r)
 	})
 
-	mux.HandleFunc("GET /person/{id}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /v1/persons/{id}", func(w http.ResponseWriter, r *http.Request) {
 		h.FindPersonByID(w, r)
 	})
 
-	mux.HandleFunc("GET /persons", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /v1/persons", func(w http.ResponseWriter, r *http.Request) {
 		h.FindAllPersons(w, r)
 	})
 }

--- a/internal/handler/purchase.go
+++ b/internal/handler/purchase.go
@@ -31,31 +31,31 @@ func NewPurchaseHandler(svc service.PurchaseService) PurchaseHandler {
 }
 
 func (h *purchaseHandler) RegisterRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("POST /purchase", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("POST /v1/purchases", func(w http.ResponseWriter, r *http.Request) {
 		h.Create(w, r)
 	})
 
-	mux.HandleFunc("PUT /purchase", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("PUT /v1/purchases", func(w http.ResponseWriter, r *http.Request) {
 		h.Update(w, r)
 	})
 
-	mux.HandleFunc("DELETE /purchase/{id}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("DELETE /v1/purchases/{id}", func(w http.ResponseWriter, r *http.Request) {
 		h.Delete(w, r)
 	})
 
-	mux.HandleFunc("GET /purchase/{id}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /v1/purchases/{id}", func(w http.ResponseWriter, r *http.Request) {
 		h.FindByID(w, r)
 	})
 
-	mux.HandleFunc("GET /purchase/date/{date}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /v1/purchases/date/{date}", func(w http.ResponseWriter, r *http.Request) {
 		h.FindByDate(w, r)
 	})
 
-	mux.HandleFunc("GET /purchase/month/{date}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /v1/purchases/month/{date}", func(w http.ResponseWriter, r *http.Request) {
 		h.FindByMonth(w, r)
 	})
 
-	mux.HandleFunc("GET /purchase/person/{id}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /v1/purchases/person/{id}", func(w http.ResponseWriter, r *http.Request) {
 		h.FindByPerson(w, r)
 	})
 

--- a/internal/handler/purchase_type.go
+++ b/internal/handler/purchase_type.go
@@ -28,23 +28,23 @@ func NewPurchaseTypeHandler(s service.PurchaseTypeUseCase) PurchaseTypeHandler {
 }
 
 func (h *purchaseTypeHandler) RegisterRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("POST /purchaseType", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("POST /v1/purchaseTypes", func(w http.ResponseWriter, r *http.Request) {
 		h.CreatePurchaseType(w, r)
 	})
 
-	mux.HandleFunc("PUT /purchaseType", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("PUT /v1/purchaseTypes", func(w http.ResponseWriter, r *http.Request) {
 		h.UpdatePurchaseType(w, r)
 	})
 
-	mux.HandleFunc("DELETE /purchaseType/{id}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("DELETE /v1/purchaseTypes/{id}", func(w http.ResponseWriter, r *http.Request) {
 		h.DeletePurchaseType(w, r)
 	})
 
-	mux.HandleFunc("GET /purchaseType/{id}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /v1/purchaseTypes/{id}", func(w http.ResponseWriter, r *http.Request) {
 		h.FindPurchaseTypeByID(w, r)
 	})
 
-	mux.HandleFunc("GET /purchaseTypes", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /v1/purchaseTypes", func(w http.ResponseWriter, r *http.Request) {
 		h.FindAllPurchaseTypes(w, r)
 	})
 }


### PR DESCRIPTION
This pull request updates the API route paths for all main resource handlers to use versioned endpoints under the `/v1/` prefix and consistent pluralized resource names. This change improves the API's organization, supports future versioning, and aligns the route naming conventions across the codebase.

**API Route Standardization**

* Updated all credit card handler routes in `internal/handler/creditcard.go` to use `/v1/creditCards` endpoints, replacing the previous unversioned and singular paths.
* Updated all payment type handler routes in `internal/handler/payment_type.go` to use `/v1/paymentTypes` endpoints, ensuring versioning and pluralization.
* Updated all person handler routes in `internal/handler/person.go` to use `/v1/persons` endpoints for consistency and future-proofing.
* Updated all purchase handler routes in `internal/handler/purchase.go` to use `/v1/purchases` endpoints, including sub-routes for date, month, and person queries.
* Updated all purchase type handler routes in `internal/handler/purchase_type.go` to use `/v1/purchaseTypes` endpoints, matching the new versioned and pluralized route scheme.
* Updated installment handler routes in `internal/handler/installment.go` to use `/v1/installments` endpoints, including sub-routes for month and notPaid queries.